### PR TITLE
Add javascript preprocessor in Favorite Extension.

### DIFF
--- a/Sessino5-ShareExtension/FavoriteExtension/Info.plist
+++ b/Sessino5-ShareExtension/FavoriteExtension/Info.plist
@@ -26,8 +26,6 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
-			<key>NSExtensionJavaScriptPreprocessingFile</key>
-			<string>Processor</string>
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
@@ -43,6 +41,8 @@
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
 			</dict>
+			<key>NSExtensionJavaScriptPreprocessingFile</key>
+			<string>Preprocessor</string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>


### PR DESCRIPTION
Now we can use javascript preprocessor in Favorite Extension. Also, we check the optional values before we wrapt them (imageToShare, urlToShare, and textToShare). The app would not crash even when there is no image.
